### PR TITLE
Add isScoped to LocalPlayer

### DIFF
--- a/NullBase/LocalPlayer.cpp
+++ b/NullBase/LocalPlayer.cpp
@@ -34,6 +34,11 @@ void LocalPlayer::forceJump()
 	wpm<int>(0, baseAddress + offs::dwForceJump);
 }
 
+bool LocalPlayer::isScoped()
+{
+	return rpm<int>(LocalPlayer::getLocalPlayer() + netvars::m_bIsScoped) >= 1;
+}
+
 int LocalPlayer::getLocalCrossID()
 {
 	auto temp = rpm<int>(LocalPlayer::getLocalPlayer() + netvars::m_iCrosshairId);

--- a/NullBase/LocalPlayer.h
+++ b/NullBase/LocalPlayer.h
@@ -20,6 +20,7 @@ namespace LocalPlayer
 
 																							//Void functions 
 	extern void				forceJump();													//Force the local player to jump
+	extern bool				isScoped();														//Check if local player is in scoped mode
 
 	extern DWORD			LocalBaseaddress;												//Localplayer base address
 }


### PR DESCRIPTION
I have added `isScoped` boolean to `LocalPlayer` class which will return whether player is in scoped mode or not.